### PR TITLE
Refactored get_started for multiple books to return text with quick replies

### DIFF
--- a/routes/messages/commands/get_started.js
+++ b/routes/messages/commands/get_started.js
@@ -5,7 +5,7 @@ const UserLibraries = require('models/db/userLibraries.js');
 const sortBooks = require('../../books/helpers/sortBooksByRating');
 // sortBooks({category_name:'Health'});
 const bookRatings = require('../../../jobs/bookRatings');
-
+const QuickReplyTemplate = require('../UI/QuickReplyTemplate.js');
 
 module.exports = async (event) => {
   const { bookCount } = event;
@@ -36,42 +36,80 @@ async function getMultipleBooks(event) {
 
   const text = userCategories.length === 0 ? firstTimeText : introText;
 
-  const buttons = [
+  // const buttons = [
+  //   {
+  //     type: 'postback',
+  //     title: 'Browse Books',
+  //     payload: JSON.stringify({
+  //       command: 'browse'
+  //     })
+  //   }
+  // ];
+
+  // if (userLibraries.length) {
+  //   buttons.push({
+  //     type: 'postback',
+  //     title: 'View Library',
+  //     payload: JSON.stringify({ command: 'library' })
+  //   });
+  // }
+
+  // buttons.push({
+  //   type: 'postback',
+  //   title: 'Get Help',
+  //   payload: JSON.stringify({ command: 'help' })
+  // });
+
+  // return [
+  //   {
+  //     attachment: {
+  //       type: 'template',
+  //       payload: {
+  //         template_type: 'button',
+  //         text,
+  //         buttons
+  //       }
+  //     }
+  //   }
+  // ];
+
+  const replyOptions = userLibraries.length ? 
+  [
     {
-      type: 'postback',
       title: 'Browse Books',
-      payload: JSON.stringify({
-        command: 'browse'
-      })
-    }
+      command: 'browse'
+    },
+    {
+      title: 'View Library',
+      command: 'library'
+    },
+    {
+      title: 'Get Help',
+      command: 'help'
+    },
+  ] :
+  [
+    {
+      title: 'Browse Books',
+      command: 'browse'
+    },
+    {
+      title: 'Get Help',
+      command: 'help'
+    },
   ];
 
-  if (userLibraries.length) {
-    buttons.push({
-      type: 'postback',
-      title: 'View Library',
-      payload: JSON.stringify({ command: 'library' })
-    });
-  }
+  const quickReplies = [];
+  replyOptions.forEach(o => {
+    const { title, command } = o;
 
-  buttons.push({
-    type: 'postback',
-    title: 'Get Help',
-    payload: JSON.stringify({ command: 'help' })
+    quickReplies.push({
+      title,
+      payload: JSON.stringify({ command: command.toLowerCase() })
+    });
   });
 
-  return [
-    {
-      attachment: {
-        type: 'template',
-        payload: {
-          template_type: 'button',
-          text,
-          buttons
-        }
-      }
-    }
-  ];
+  return [ await QuickReplyTemplate(text, quickReplies)];
 }
 
 async function getSingleBook(event) {


### PR DESCRIPTION
# Description
- Get Started command will respond with intro text and quick replies. If user has books in their library, 'View Library' will be a quick reply option. Otherwise, the options are 'browse books' and 'get help'

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [ x I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ x I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
