### PR TITLE
Fixed billing/checkout bug; fixed 'More' quick reply; Changed various text responses

### DIFF
--- a/routes/billing/index.js
+++ b/routes/billing/index.js
@@ -19,8 +19,8 @@ router.get('/productsandplans/:id', async (req, res) => {
     
     // Check if user has subscription id; if they do get the subscription plan id:
     const subID = await user.stripe_subscription_id;
-    const subscription = subID ? await stripe.subscriptions.retrieve(subID) : {};
-    const currentPlanID = subscription.plan.id;
+    const subscription = subID ? await stripe.subscriptions.retrieve(subID) : null;
+    const currentPlanID = subscription ? subscription.plan.id : null;
 
     // Sort plans in ascending order of price (amount):
     plans = plans.sort((a, b) => {

--- a/routes/messages/UI/BookTemplate.js
+++ b/routes/messages/UI/BookTemplate.js
@@ -40,7 +40,7 @@ module.exports = async (event, books) => {
 
               buttons.push({
                 type: 'postback',
-                title: isInLibrary ? 'Remove from Library' : 'Save to Library',
+                title: isInLibrary ? 'Remove from Library' : 'Add to Library',
                 payload: JSON.stringify({
                   command: 'toggle_in_library',
                   book_id,

--- a/routes/messages/commands/browse.js
+++ b/routes/messages/commands/browse.js
@@ -19,7 +19,7 @@ module.exports = async event => {
     return request_email(event);
   }
 
-  const text = 'Which of your genres would you like to browse?';
+  const text = 'Which category would you like to browse?';
 
   const categories = await Promise.all(
     userCategories.map(

--- a/routes/messages/commands/get_books_from_category.js
+++ b/routes/messages/commands/get_books_from_category.js
@@ -10,15 +10,15 @@ module.exports = async (event) => {
 
   const { isEndOfCategory, books } = await getBooksInCategories(user_id, category_id);
 
-  const text = 'Would you like to see more books from this genre? Or, peruse another genre?';
+  const text = `Would you like to see more books on ${currentCat[0].name}`;
   const quickReplies = [];
   const options = [
     {
-      title: `More from ${currentCat[0].name}`,
+      title: 'More',
       command: 'get_books_from_category'
     },
     {
-      title: 'Other categories',
+      title: 'Other',
       command: 'browse'
     }
   ];

--- a/routes/messages/commands/get_books_from_category.js
+++ b/routes/messages/commands/get_books_from_category.js
@@ -15,7 +15,8 @@ module.exports = async (event) => {
   const options = [
     {
       title: 'More',
-      command: 'get_books_from_category'
+      command: 'get_books_from_category',
+      category_id
     },
     {
       title: 'Other',
@@ -24,11 +25,14 @@ module.exports = async (event) => {
   ];
 
   options.forEach((opt) => {
-    const { title, command } = opt;
+    const { title, command, category_id } = opt;
 
     quickReplies.push({
       title,
-      payload: JSON.stringify({ command: command.toLowerCase() })
+      payload: JSON.stringify({ 
+        command: command.toLowerCase(),
+        category_id 
+      })
     });
   });
   const browseQR = await browse(event);

--- a/routes/messages/commands/get_books_from_category.js
+++ b/routes/messages/commands/get_books_from_category.js
@@ -10,7 +10,7 @@ module.exports = async (event) => {
 
   const { isEndOfCategory, books } = await getBooksInCategories(user_id, category_id);
 
-  const text = `Would you like to see more books on ${currentCat[0].name}`;
+  const text = `Would you like to see more books on ${currentCat[0].name}?`;
   const quickReplies = [];
   const options = [
     {

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const cors = require('cors');
 
 // Jobs -- Tasks running on a schedule
 require('./jobs/timedMessages.js');
-require('./jobs/bookRatings.js')();
+// require('./jobs/bookRatings.js')();
 
 // Import routes
 const messageRouter = require('./routes/messages/');


### PR DESCRIPTION
# Description
- in endpoint api/billing/productsandplans/:id and error was thrown when no stipe subscription existed becaue there was no logical handling of that case. Now, if no stripe subscription exists, currentPlanId is set to null

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested by making request to endpoint with valid data for existing user (facebook_id) and without. If no user exists, or if user has not created a stripe, subscription, API responds with no products and front end display message saying there are no products available to subscribe to.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
